### PR TITLE
(BKR-942) let beaker use either old pkg or new pkgng tools on FreeBSD

### DIFF
--- a/lib/beaker/host/freebsd/pkg.rb
+++ b/lib/beaker/host/freebsd/pkg.rb
@@ -1,13 +1,28 @@
 module FreeBSD::Pkg
   include Beaker::CommandFactory
 
-  def install_package(name, cmdline_args = nil, opts = {})
-    cmdline_args ||= '-y'
-    execute("pkg install #{cmdline_args} #{name}", opts) { |result| result }
+  def shell_check_pkgng
+    # See manpage of pkg(8), the paragraph devoted to -N flag
+    # https://www.freebsd.org/cgi/man.cgi?query=pkg
+    'TMPDIR=/dev/null ASSUME_ALWAYS_YES=1 PACKAGESITE=file:///nonexist ' \
+    'pkg info -x "pkg(-devel)?\\$" > /dev/null 2>&1'
   end
 
-  def check_for_package(name, opts = {})
-    execute("pkg info #{name}", opts) { |result| result }
+  def shell_ifelse(cond, stmt_t, stmt_f)
+    "if #{cond}; then #{stmt_t}; else #{stmt_f}; fi"
   end
 
+  def install_package(package, cmdline_args = nil, opts = {})
+    cmd = shell_ifelse shell_check_pkgng,
+                       "pkg install #{cmdline_args || '-y'} #{package}",
+                       "pkg_add #{cmdline_args || '-r'} #{package}"
+    execute("/bin/sh -c '#{cmd}'", opts) { |result| result }
+  end
+
+  def check_for_package(package, opts = {})
+    cmd = shell_ifelse shell_check_pkgng,
+                       "pkg info #{package}",
+                       "pkg_info -Iqx #{package} 2> /dev/null || true"
+    execute("/bin/sh -c '#{cmd}'", opts) { |result| result }
+  end
 end

--- a/spec/beaker/host/freebsd/pkg_spec.rb
+++ b/spec/beaker/host/freebsd/pkg_spec.rb
@@ -27,11 +27,16 @@ module Beaker
     let (:opts)     { @opts || {} }
     let (:logger)   { double( 'logger' ).as_null_object }
     let (:instance) { FreeBSDPkgTest.new(opts, logger) }
+    let(:cond) do
+      'TMPDIR=/dev/null ASSUME_ALWAYS_YES=1 PACKAGESITE=file:///nonexist pkg info -x "pkg(-devel)?\\$" > /dev/null 2>&1'
+    end
 
     context "install_package" do
+      let(:st) { 'pkg install -y rsync' }
+      let(:sf) { 'pkg_add -r rsync' }
 
       it "runs the correct install command" do
-        expect( Beaker::Command ).to receive(:new).with('pkg install -y rsync', [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( Beaker::Command ).to receive(:new).with("/bin/sh -c 'if #{cond}; then #{st}; else #{sf}; fi'", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
         expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
         instance.install_package('rsync')
       end
@@ -39,9 +44,11 @@ module Beaker
     end
 
     context "check_for_package" do
+      let(:st) { 'pkg info rsync' }
+      let(:sf) { 'pkg_info -Iqx rsync 2> /dev/null || true' }
 
       it "runs the correct checking command" do
-        expect( Beaker::Command ).to receive(:new).with('pkg info rsync', [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( Beaker::Command ).to receive(:new).with("/bin/sh -c 'if #{cond}; then #{st}; else #{sf}; fi'", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
         expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
         instance.check_for_package('rsync')
       end


### PR DESCRIPTION
This PR enables beaker to install and query packages on new (>=9.3) and old (<9.3) versions of FreeBSD. The proposed code was used by me as [a workaround](https://github.com/ptomulik/puppet-portsng/blob/master/spec/patches/lib/beaker/host/freebsd/pkg.rb) in [ptomulik/puppet-portsng](https://github.com/ptomulik/puppet-portsng/) puppet module and worked for all FreeBSD versions between 9.0 and 11.0, where the older versions (9.0 .. 9.2) used the old pkg toolstack and newer (9.3 ... 11.0) the new pkgng suite. A similar patch was proposed for specinfra as  PR [specinfra/581](https://github.com/mizzy/specinfra/pull/581).