### PR TITLE
Run host generation tests in Travis

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,10 +26,7 @@ task :history do
   Rake::Task['history:gen'].invoke
 end
 
-task :travis do
-  Rake::Task['yard'].invoke if !Beaker::Shared::Semvar.version_is_less(RUBY_VERSION, '2.0.0')
-  Rake::Task['spec'].invoke
-end
+task travis: [:yard, :test]
 
 module HarnessOptions
   defaults = {


### PR DESCRIPTION
This modifies the `:travis` rake task to run all available tests in the
Rakefile, including host generation tests and Beaker subcommand tests.
This ensures that any changes that may break Beaker host generation or
subcommands will be caught before the change is merged.